### PR TITLE
Add CLI subproject for generating FHIR resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build creator/FSharpFHIR.Creator.fsproj
 
 ## CLI Usage
 
-The CLIs use the [Charm](https://charm.land/) library.
-
 ### Validate a resource
 
 To validate a JSON file containing a FHIR resource run:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# FSharpFHIR
+
+A basic FHIR domain model and CLI validator written in F#.
+
+## Building
+
+This repository targets .NET 8. Build the library or CLIs with:
+
+```bash
+# build the domain model library
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build src/FSharpFHIR.fsproj
+
+# build the validator CLI
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build cli/FSharpFHIR.Cli.fsproj
+
+# build the resource creator CLI
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build creator/FSharpFHIR.Creator.fsproj
+```
+
+## CLI Usage
+
+The CLIs use the [Charm](https://charm.land/) library.
+
+### Validate a resource
+
+To validate a JSON file containing a FHIR resource run:
+
+```bash
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet run --project cli -- validate --file path/to/resource.json
+```
+
+If the resource is valid the tool prints `Resource is valid`; otherwise it lists the validation errors.
+
+### Example
+
+Validate the provided sample patient resource:
+
+```bash
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet run --project cli -- validate --file examples/patient.json
+```
+
+This should output:
+
+```text
+Resource is valid
+```
+
+### Create a resource
+
+Generate a minimal `Patient` resource as JSON:
+
+```bash
+DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet run --project creator -- create patient --name "Jane Doe" --gender female --birthDate 1980-01-01
+```
+
+The JSON is printed to stdout. Supply `--out path/to/file.json` to write it to disk.
+

--- a/cli/FSharpFHIR.Cli.fsproj
+++ b/cli/FSharpFHIR.Cli.fsproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Charm" Version="0.5.0" />
+    <ProjectReference Include="../src/FSharpFHIR.fsproj" />
+  </ItemGroup>
+</Project>

--- a/cli/FSharpFHIR.Cli.fsproj
+++ b/cli/FSharpFHIR.Cli.fsproj
@@ -7,7 +7,6 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Charm" Version="0.5.0" />
     <ProjectReference Include="../src/FSharpFHIR.fsproj" />
   </ItemGroup>
 </Project>

--- a/cli/Program.fs
+++ b/cli/Program.fs
@@ -1,0 +1,34 @@
+namespace FSharpFHIR.Cli
+
+open System
+open FSharpFHIR
+open FSharpFHIR.Validator
+open Charm
+
+module Program =
+    /// Command that validates a JSON file containing a FHIR resource
+    let validateCommand =
+        cmd "validate" {
+            desc "Validate a FHIR resource provided as a JSON file"
+            opt "file" {
+                desc "Path to the JSON resource file"
+            }
+            run (fun ctx ->
+                match ctx?file with
+                | :? string as file ->
+                    let errors = Validator.validateFile file
+                    if List.isEmpty errors then
+                        printfn "Resource is valid"
+                        0
+                    else
+                        printfn "Validation errors:"
+                        errors |> List.iter (printfn "- %s")
+                        1
+                | _ ->
+                    printfn "--file option is required"
+                    1)
+        }
+
+    [<EntryPoint>]
+    let main argv =
+        run validateCommand argv

--- a/cli/Program.fs
+++ b/cli/Program.fs
@@ -1,4 +1,4 @@
-namespace FSharpFHIR.Cli
+module FSharpFHIR.Cli
 
 open System
 open FSharpFHIR.Validator

--- a/cli/Program.fs
+++ b/cli/Program.fs
@@ -1,34 +1,22 @@
 namespace FSharpFHIR.Cli
 
 open System
-open FSharpFHIR
 open FSharpFHIR.Validator
-open Charm
 
-module Program =
-    /// Command that validates a JSON file containing a FHIR resource
-    let validateCommand =
-        cmd "validate" {
-            desc "Validate a FHIR resource provided as a JSON file"
-            opt "file" {
-                desc "Path to the JSON resource file"
-            }
-            run (fun ctx ->
-                match ctx?file with
-                | :? string as file ->
-                    let errors = Validator.validateFile file
-                    if List.isEmpty errors then
-                        printfn "Resource is valid"
-                        0
-                    else
-                        printfn "Validation errors:"
-                        errors |> List.iter (printfn "- %s")
-                        1
-                | _ ->
-                    printfn "--file option is required"
-                    1)
-        }
-
-    [<EntryPoint>]
-    let main argv =
-        run validateCommand argv
+/// Basic validator CLI without external dependencies
+[<EntryPoint>]
+let main argv =
+    let args = Array.toList argv
+    match args with
+    | "validate" :: "--file" :: file :: _ ->
+        let errors = Validator.validateFile file
+        if List.isEmpty errors then
+            printfn "Resource is valid"
+            0
+        else
+            printfn "Validation errors:"
+            errors |> List.iter (printfn "- %s")
+            1
+    | _ ->
+        printfn "Usage: validate --file <path>"
+        1

--- a/creator/FSharpFHIR.Creator.fsproj
+++ b/creator/FSharpFHIR.Creator.fsproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Charm" Version="0.5.0" />
+    <ProjectReference Include="../src/FSharpFHIR.fsproj" />
+  </ItemGroup>
+</Project>

--- a/creator/FSharpFHIR.Creator.fsproj
+++ b/creator/FSharpFHIR.Creator.fsproj
@@ -7,7 +7,6 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Charm" Version="0.5.0" />
     <ProjectReference Include="../src/FSharpFHIR.fsproj" />
   </ItemGroup>
 </Project>

--- a/creator/Program.fs
+++ b/creator/Program.fs
@@ -1,0 +1,50 @@
+namespace FSharpFHIR.Creator
+
+open System
+open FSharpFHIR
+open Charm
+
+module Program =
+    /// Command that creates a simple Patient resource as JSON
+    let patientCommand =
+        cmd "patient" {
+            desc "Create a minimal Patient resource"
+            opt "name" { desc "Patient name" }
+            opt "gender" { desc "Gender (male|female|other|unknown)" }
+            opt "birthDate" { desc "Birth date (YYYY-MM-DD)" }
+            opt "out" { desc "Output file (defaults to stdout)" }
+            run (fun ctx ->
+                let name = ctx?name |> Option.ofObj |> Option.map string
+                let gender = ctx?gender |> Option.ofObj |> Option.map string
+                let birth = ctx?birthDate |> Option.ofObj |> Option.map string
+                let outFile = ctx?out |> Option.ofObj |> Option.map string
+
+                // Build minimal Patient JSON
+                let parts =
+                    [ Some "\"resourceType\":\"Patient\"";
+                      name |> Option.map (fun n -> $"\"name\":[{{\"text\":\"{n}\"}}]");
+                      gender |> Option.map (fun g -> $"\"gender\":\"{g}\"");
+                      birth |> Option.map (fun b -> $"\"birthDate\":\"{b}\"") ]
+                    |> List.choose id
+                let json = "{" + String.Join(",", parts) + "}"
+
+                match outFile with
+                | Some path ->
+                    System.IO.File.WriteAllText(path, json)
+                    printfn "Wrote Patient resource to %s" path
+                    0
+                | None ->
+                    printfn "%s" json
+                    0)
+        }
+
+    /// Root create command
+    let createCommand =
+        cmd "create" {
+            desc "Create FHIR resources"
+            cmd patientCommand
+        }
+
+    [<EntryPoint>]
+    let main argv =
+        run createCommand argv

--- a/creator/Program.fs
+++ b/creator/Program.fs
@@ -1,4 +1,4 @@
-namespace FSharpFHIR.Creator
+module FSharpFHIR.Creator
 
 open System
 

--- a/examples/patient.json
+++ b/examples/patient.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "name": [
+    {
+      "family": "Smith",
+      "given": ["John"]
+    }
+  ]
+}

--- a/src/AllergyIntolerance.fs
+++ b/src/AllergyIntolerance.fs
@@ -1,0 +1,13 @@
+namespace FSharpFHIR
+
+/// AllergyIntolerance resource
+// See: https://hl7.org/fhir/allergyintolerance.html
+
+type AllergyIntolerance = {
+    resource : DomainResource
+    identifier : Identifier list
+    clinicalStatus : CodeableConcept option
+    verificationStatus : CodeableConcept option
+    code : CodeableConcept option
+    patient : Reference
+}

--- a/src/Appointment.fs
+++ b/src/Appointment.fs
@@ -1,0 +1,24 @@
+namespace FSharpFHIR
+
+/// Appointment resource
+// See: https://hl7.org/fhir/appointment.html
+
+type Appointment = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : AppointmentStatus
+    start : FhirDateTime option
+    end_ : FhirDateTime option
+    participant : Reference list
+}
+and AppointmentStatus =
+    | Proposed
+    | Pending
+    | Booked
+    | Arrived
+    | Fulfilled
+    | Cancelled
+    | NoShow
+    | EnteredInError
+    | CheckedIn
+    | Waitlist

--- a/src/Condition.fs
+++ b/src/Condition.fs
@@ -1,0 +1,13 @@
+namespace FSharpFHIR
+
+/// Condition resource
+// See: https://hl7.org/fhir/condition.html
+
+type Condition = {
+    resource : DomainResource
+    identifier : Identifier list
+    clinicalStatus : CodeableConcept option
+    verificationStatus : CodeableConcept option
+    code : CodeableConcept option
+    subject : Reference option
+}

--- a/src/DiagnosticReport.fs
+++ b/src/DiagnosticReport.fs
@@ -1,0 +1,25 @@
+namespace FSharpFHIR
+
+/// DiagnosticReport resource
+// See: https://hl7.org/fhir/diagnosticreport.html
+
+type DiagnosticReport = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : DiagnosticReportStatus
+    code : CodeableConcept option
+    subject : Reference option
+    effective : FhirDateTime option
+    result : Reference list
+}
+and DiagnosticReportStatus =
+    | Registered
+    | Partial
+    | Preliminary
+    | Final
+    | Amended
+    | Corrected
+    | Appended
+    | Cancelled
+    | EnteredInError
+    | Unknown

--- a/src/Encounter.fs
+++ b/src/Encounter.fs
@@ -1,0 +1,22 @@
+namespace FSharpFHIR
+
+/// Encounter resource
+// See: https://hl7.org/fhir/encounter.html
+
+type Encounter = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : EncounterStatus
+    class : Coding option
+    subject : Reference option
+    period : Period option
+}
+and EncounterStatus =
+    | Planned
+    | InProgress
+    | OnHold
+    | Discharged
+    | Completed
+    | Cancelled
+    | EnteredInError
+    | Unknown

--- a/src/Encounter.fs
+++ b/src/Encounter.fs
@@ -7,7 +7,7 @@ type Encounter = {
     resource : DomainResource
     identifier : Identifier list
     status : EncounterStatus
-    class : Coding option
+    ``class`` : Coding option
     subject : Reference option
     period : Period option
 }

--- a/src/FSharpFHIR.fsproj
+++ b/src/FSharpFHIR.fsproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>Domain model for FHIR R5 represented in F#</Description>
+    <PackageId>FSharpFHIR</PackageId>
+    <AssemblyName>FSharpFHIR</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Fhir.fs" />
+    <Compile Include="AllergyIntolerance.fs" />
+    <Compile Include="Appointment.fs" />
+    <Compile Include="Condition.fs" />
+    <Compile Include="DiagnosticReport.fs" />
+    <Compile Include="Encounter.fs" />
+    <Compile Include="Immunization.fs" />
+    <Compile Include="Medication.fs" />
+    <Compile Include="MedicationAdministration.fs" />
+    <Compile Include="MedicationRequest.fs" />
+    <Compile Include="Observation.fs" />
+    <Compile Include="Organization.fs" />
+    <Compile Include="Patient.fs" />
+    <Compile Include="Practitioner.fs" />
+    <Compile Include="Procedure.fs" />
+    <Compile Include="ServiceRequest.fs" />
+    <Compile Include="Validator.fs" />
+  </ItemGroup>
+</Project>

--- a/src/Fhir.fs
+++ b/src/Fhir.fs
@@ -1,0 +1,154 @@
+namespace FSharpFHIR
+
+open System
+
+/// Primitive FHIR types
+// These aliases reflect the primitive data types defined by the FHIR specification
+// See: https://hl7.org/fhir/datatypes.html
+
+type FhirBoolean = bool
+
+type FhirInteger = int
+
+type FhirString = string
+
+type FhirDecimal = decimal
+
+type FhirUri = Uri
+
+type FhirDateTime = DateTime
+
+/// Base Element type that allows extensions
+// Almost all FHIR structures derive from Element
+
+type Element = {
+    id : string option
+    extension : Extension list
+}
+and Extension = {
+    url : FhirUri
+    value : ElementValue option
+}
+and ElementValue =
+    | ValueBoolean of FhirBoolean
+    | ValueInteger of FhirInteger
+    | ValueString of FhirString
+    | ValueDecimal of FhirDecimal
+    | ValueDateTime of FhirDateTime
+    | ValueUri of FhirUri
+
+/// Meta information supported on all resources
+// See: https://hl7.org/fhir/resource.html#Meta
+
+type Meta = {
+    versionId : string option
+    lastUpdated : FhirDateTime option
+    profile : FhirUri list
+}
+
+/// Narrative block
+// See: https://hl7.org/fhir/narrative.html
+
+type Narrative = {
+    status : NarrativeStatus
+    div : string
+}
+and NarrativeStatus =
+    | Generated
+    | Extensions
+    | Additional
+    | Empty
+
+/// Generic Resource definition (minimal subset)
+
+type Resource = {
+    id : string option
+    meta : Meta option
+    language : string option
+}
+
+/// DomainResource extends Resource with narrative and extensions
+
+type DomainResource = {
+    resource : Resource
+    text : Narrative option
+    contained : DomainResource list
+    extension : Extension list
+    modifierExtension : Extension list
+}
+
+/// Identifier data type used by many resources
+// See: https://hl7.org/fhir/datatypes.html#Identifier
+
+type Identifier = {
+    use : IdentifierUse option
+    system : FhirUri option
+    value : FhirString option
+}
+and IdentifierUse =
+    | Usual
+    | Official
+    | Temp
+    | Secondary
+    | Old
+
+/// HumanName data type
+// See: https://hl7.org/fhir/datatypes.html#HumanName
+
+type HumanName = {
+    use : NameUse option
+    text : FhirString option
+    family : FhirString option
+    given : FhirString list
+}
+and NameUse =
+    | Usual
+    | Official
+    | Temp
+    | Nickname
+    | Anonymous
+    | Old
+    | Maiden
+
+/// Administrative gender
+// See: https://hl7.org/fhir/valueset-administrative-gender.html
+
+type AdministrativeGender =
+    | Male
+    | Female
+    | Other
+    | Unknown
+
+/// Coding data type
+// See: https://hl7.org/fhir/datatypes.html#Coding
+
+type Coding = {
+    system : FhirUri option
+    code : FhirString option
+    display : FhirString option
+}
+
+/// CodeableConcept data type
+// See: https://hl7.org/fhir/datatypes.html#CodeableConcept
+
+type CodeableConcept = {
+    coding : Coding list
+    text : FhirString option
+}
+
+/// Reference data type
+// See: https://hl7.org/fhir/references.html
+
+type Reference = {
+    reference : FhirString option
+    display : FhirString option
+}
+
+/// Period data type
+// See: https://hl7.org/fhir/datatypes.html#Period
+
+type Period = {
+    start : FhirDateTime option
+    end : FhirDateTime option
+}
+

--- a/src/Fhir.fs
+++ b/src/Fhir.fs
@@ -81,7 +81,7 @@ type DomainResource = {
 // See: https://hl7.org/fhir/datatypes.html#Identifier
 
 type Identifier = {
-    use : IdentifierUse option
+    ``use`` : IdentifierUse option
     system : FhirUri option
     value : FhirString option
 }
@@ -96,7 +96,7 @@ and IdentifierUse =
 // See: https://hl7.org/fhir/datatypes.html#HumanName
 
 type HumanName = {
-    use : NameUse option
+    ``use`` : NameUse option
     text : FhirString option
     family : FhirString option
     given : FhirString list
@@ -149,6 +149,6 @@ type Reference = {
 
 type Period = {
     start : FhirDateTime option
-    end : FhirDateTime option
+    ``end`` : FhirDateTime option
 }
 

--- a/src/Immunization.fs
+++ b/src/Immunization.fs
@@ -1,0 +1,16 @@
+namespace FSharpFHIR
+
+/// Immunization resource
+// See: https://hl7.org/fhir/immunization.html
+
+type Immunization = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : ImmunizationStatus
+    vaccineCode : CodeableConcept
+    patient : Reference
+}
+and ImmunizationStatus =
+    | Completed
+    | EnteredInError
+    | NotDone

--- a/src/Medication.fs
+++ b/src/Medication.fs
@@ -1,0 +1,9 @@
+namespace FSharpFHIR
+
+/// Medication resource
+// See: https://hl7.org/fhir/medication.html
+
+type Medication = {
+    resource : DomainResource
+    code : CodeableConcept option
+}

--- a/src/MedicationAdministration.fs
+++ b/src/MedicationAdministration.fs
@@ -1,0 +1,21 @@
+namespace FSharpFHIR
+
+/// MedicationAdministration resource
+// See: https://hl7.org/fhir/medicationadministration.html
+
+type MedicationAdministration = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : MedicationAdministrationStatus
+    medication : CodeableConcept option
+    subject : Reference option
+    effective : FhirDateTime option
+}
+and MedicationAdministrationStatus =
+    | InProgress
+    | NotDone
+    | OnHold
+    | Completed
+    | EnteredInError
+    | Stopped
+    | Unknown

--- a/src/MedicationRequest.fs
+++ b/src/MedicationRequest.fs
@@ -1,0 +1,31 @@
+namespace FSharpFHIR
+
+/// MedicationRequest resource
+// See: https://hl7.org/fhir/medicationrequest.html
+
+type MedicationRequest = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : MedicationRequestStatus
+    intent : MedicationRequestIntent
+    medication : CodeableConcept option
+    subject : Reference option
+}
+and MedicationRequestStatus =
+    | Active
+    | OnHold
+    | Cancelled
+    | Completed
+    | EnteredInError
+    | Stopped
+    | Draft
+    | Unknown
+and MedicationRequestIntent =
+    | Order
+    | Plan
+    | Proposal
+    | OriginalOrder
+    | ReflexOrder
+    | FillerOrder
+    | InstanceOrder
+    | Option

--- a/src/Observation.fs
+++ b/src/Observation.fs
@@ -1,0 +1,19 @@
+namespace FSharpFHIR
+
+/// Observation resource
+// See: https://hl7.org/fhir/observation.html
+
+type Observation = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : ObservationStatus
+    code : CodeableConcept option
+    subject : Reference option
+    effective : FhirDateTime option
+    value : ElementValue option
+}
+and ObservationStatus =
+    | Registered
+    | Preliminary
+    | Final
+    | Amended

--- a/src/Organization.fs
+++ b/src/Organization.fs
@@ -1,0 +1,11 @@
+namespace FSharpFHIR
+
+/// Organization resource
+// See: https://hl7.org/fhir/organization.html
+
+type Organization = {
+    resource : DomainResource
+    identifier : Identifier list
+    active : FhirBoolean option
+    name : FhirString option
+}

--- a/src/Patient.fs
+++ b/src/Patient.fs
@@ -1,0 +1,14 @@
+namespace FSharpFHIR
+
+/// Simple Patient resource representation
+// This is a minimal subset of the Patient definition.
+// Full definition includes many more fields. See: https://hl7.org/fhir/patient.html
+
+type Patient = {
+    resource : DomainResource
+    identifier : Identifier list
+    active : FhirBoolean option
+    name : HumanName list
+    gender : AdministrativeGender option
+    birthDate : FhirDateTime option
+}

--- a/src/Practitioner.fs
+++ b/src/Practitioner.fs
@@ -1,0 +1,11 @@
+namespace FSharpFHIR
+
+/// Practitioner resource
+// See: https://hl7.org/fhir/practitioner.html
+
+type Practitioner = {
+    resource : DomainResource
+    identifier : Identifier list
+    active : FhirBoolean option
+    name : HumanName list
+}

--- a/src/Procedure.fs
+++ b/src/Procedure.fs
@@ -1,0 +1,20 @@
+namespace FSharpFHIR
+
+/// Procedure resource
+// See: https://hl7.org/fhir/procedure.html
+
+type Procedure = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : ProcedureStatus
+    code : CodeableConcept option
+    subject : Reference option
+    performed : FhirDateTime option
+}
+and ProcedureStatus =
+    | Preparation
+    | InProgress
+    | Completed
+    | EnteredInError
+    | Stopped
+    | Unknown

--- a/src/ServiceRequest.fs
+++ b/src/ServiceRequest.fs
@@ -1,0 +1,31 @@
+namespace FSharpFHIR
+
+/// ServiceRequest resource
+// See: https://hl7.org/fhir/servicerequest.html
+
+type ServiceRequest = {
+    resource : DomainResource
+    identifier : Identifier list
+    status : ServiceRequestStatus
+    intent : ServiceRequestIntent
+    code : CodeableConcept option
+    subject : Reference option
+}
+and ServiceRequestStatus =
+    | Draft
+    | Active
+    | OnHold
+    | Revoked
+    | Completed
+    | EnteredInError
+    | Unknown
+and ServiceRequestIntent =
+    | Proposal
+    | Plan
+    | Directive
+    | Order
+    | OriginalOrder
+    | ReflexOrder
+    | FillerOrder
+    | InstanceOrder
+    | Option

--- a/src/Validator.fs
+++ b/src/Validator.fs
@@ -1,0 +1,25 @@
+namespace FSharpFHIR
+
+open System
+open System.Text.Json
+
+module Validator =
+    /// Validate FHIR resource given as JSON string. Returns list of error messages.
+    let validate (json:string) : string list =
+        try
+            use doc = JsonDocument.Parse(json)
+            let root = doc.RootElement
+            if root.TryGetProperty("resourceType", ref Unchecked.defaultof<JsonElement>) then
+                []
+            else
+                ["Missing required 'resourceType' property"]
+        with ex ->
+            ["Invalid JSON: " + ex.Message]
+
+    /// Validate a JSON file containing FHIR resource
+    let validateFile (path:string) : string list =
+        if not (IO.File.Exists path) then
+            [sprintf "File '%s' does not exist" path]
+        else
+            let json = IO.File.ReadAllText path
+            validate json


### PR DESCRIPTION
## Summary
- introduce a new `creator` CLI project using Charm to generate minimal Patient resources
- wire the project to the domain model and document its usage in the README

## Testing
- `dotnet --info` *(fails: command not found)*
- `dotnet build src/FSharpFHIR.fsproj` *(fails: command not found)*
- `dotnet build cli/FSharpFHIR.Cli.fsproj` *(fails: command not found)*
- `dotnet build creator/FSharpFHIR.Creator.fsproj` *(fails: command not found)*
- `dotnet run --project creator -- create patient --name "Jane Doe" --gender female --birthDate 1980-01-01` *(fails: command not found)*
- `dotnet run --project cli -- validate --file examples/patient.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d96eea8e483328e8aef72d4cce0bb