### PR TITLE
Add basic test suite and sample FHIR data

### DIFF
--- a/examples/patient.json
+++ b/examples/patient.json
@@ -1,0 +1,14 @@
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Chalmers",
+      "given": ["Peter", "James"]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1974-12-25"
+}

--- a/tests/Cli.fs
+++ b/tests/Cli.fs
@@ -1,0 +1,19 @@
+module FSharpFHIR.Cli
+
+open FSharpFHIR.ResourceValidation
+
+/// Parses CLI arguments and runs the appropriate command.
+/// Currently only supports `validate <file>` which validates the provided
+/// JSON file and returns a process exit code.
+let run (args: string[]) =
+    match args with
+    | [| "validate"; file |] ->
+        if isValid file then
+            printfn "Validation succeeded"
+            0 // exit success
+        else
+            printfn "Validation failed"
+            1 // exit failure
+    | _ ->
+        printfn "Usage: validate <file>"
+        1 // exit failure for incorrect usage

--- a/tests/CliTests.fs
+++ b/tests/CliTests.fs
@@ -1,0 +1,21 @@
+module FSharpFHIR.Tests.CliTests
+
+open Xunit
+open System.IO
+open FSharpFHIR.Cli
+open FSharpFHIR.ResourceValidation
+
+/// Successful validation should yield exit code 0.
+[<Fact>]
+let ``validate command returns success`` () =
+    let exitCode = run [| "validate"; patientSamplePath |]
+    Assert.Equal(0, exitCode)
+
+/// Invalid JSON should trigger a validation failure and non-zero exit code.
+[<Fact>]
+let ``validate command returns failure for invalid JSON`` () =
+    let temp = Path.GetTempFileName()
+    File.WriteAllText(temp, "{}");
+    let exitCode = run [| "validate"; temp |]
+    File.Delete(temp)
+    Assert.Equal(1, exitCode)

--- a/tests/FSharpFHIR.Tests.fsproj
+++ b/tests/FSharpFHIR.Tests.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ResourceValidation.fs" />
+    <Compile Include="Cli.fs" />
+    <Compile Include="PrimitiveSerializationTests.fs" />
+    <Compile Include="ResourceValidationTests.fs" />
+    <Compile Include="CliTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/PrimitiveSerializationTests.fs
+++ b/tests/PrimitiveSerializationTests.fs
@@ -1,0 +1,32 @@
+module FSharpFHIR.Tests.PrimitiveSerializationTests
+
+open Xunit
+open System.Text.Json
+
+/// Helpers for round-trip serialization using System.Text.Json.
+module Primitive =
+    /// Serialize a value to JSON and deserialize it back.
+    let roundTrip<'a> (value: 'a) =
+        let json = JsonSerializer.Serialize<'a> value
+        JsonSerializer.Deserialize<'a> json
+
+/// Verifies that strings serialize and deserialize without loss.
+[<Fact>]
+let ``string roundtrips`` () =
+    let v = "hello"
+    let result = Primitive.roundTrip v
+    Assert.Equal(v, result)
+
+/// Verifies that integers serialize and deserialize without loss.
+[<Fact>]
+let ``int roundtrips`` () =
+    let v = 42
+    let result = Primitive.roundTrip v
+    Assert.Equal(v, result)
+
+/// Verifies that booleans serialize and deserialize without loss.
+[<Fact>]
+let ``boolean roundtrips`` () =
+    let v = true
+    let result = Primitive.roundTrip v
+    Assert.Equal(v, result)

--- a/tests/ResourceValidation.fs
+++ b/tests/ResourceValidation.fs
@@ -1,0 +1,20 @@
+module FSharpFHIR.ResourceValidation
+
+open System.IO
+open System.Text.Json
+
+/// Path to the sample Patient resource JSON used by tests and CLI scenarios.
+let patientSamplePath =
+    Path.Combine(__SOURCE_DIRECTORY__, "..", "examples", "patient.json")
+
+/// Performs a basic validation by ensuring the JSON contains a Patient resource
+/// with an `id` field.
+let isValid (path: string) =
+    let json = File.ReadAllText path
+    use doc = JsonDocument.Parse json
+    let root = doc.RootElement
+    let mutable resourceType = Unchecked.defaultof<JsonElement>
+    let mutable id = Unchecked.defaultof<JsonElement>
+    let hasResourceType = root.TryGetProperty("resourceType", &resourceType)
+    let hasId = root.TryGetProperty("id", &id)
+    hasResourceType && hasId && resourceType.GetString() = "Patient"

--- a/tests/ResourceValidationTests.fs
+++ b/tests/ResourceValidationTests.fs
@@ -1,0 +1,9 @@
+module FSharpFHIR.Tests.ResourceValidationTests
+
+open Xunit
+open FSharpFHIR.ResourceValidation
+
+/// Ensures the bundled sample patient resource passes validation.
+[<Fact>]
+let ``patient example is valid`` () =
+    Assert.True(isValid patientSamplePath)


### PR DESCRIPTION
## Summary
- set up `FSharpFHIR.Tests` targeting .NET 8
- validate sample Patient JSON and implement simple CLI validation helper
- test primitive serialization and CLI scenarios
- document validation and CLI utilities and tests for clarity

## Testing
- `dotnet test tests/FSharpFHIR.Tests.fsproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_689dabc036748332966d5a2e3594ddd5