### PR TITLE
Add basic test suite and sample FHIR data

### DIFF
--- a/examples/patient.json
+++ b/examples/patient.json
@@ -1,0 +1,14 @@
+{
+  "resourceType": "Patient",
+  "id": "example",
+  "active": true,
+  "name": [
+    {
+      "use": "official",
+      "family": "Chalmers",
+      "given": ["Peter", "James"]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1974-12-25"
+}

--- a/tests/Cli.fs
+++ b/tests/Cli.fs
@@ -1,0 +1,19 @@
+module FSharpFHIR.Cli
+
+open FSharpFHIR.ResourceValidation
+
+/// Parses CLI arguments and runs the appropriate command.
+/// Currently only supports `validate <file>` which validates the provided
+/// JSON file and returns a process exit code.
+let run (args: string[]) =
+    match args with
+    | [| "validate"; file |] ->
+        if isValid file then
+            printfn "Validation succeeded"
+            0 // exit success
+        else
+            printfn "Validation failed"
+            1 // exit failure
+    | _ ->
+        printfn "Usage: validate <file>"
+        1 // exit failure for incorrect usage

--- a/tests/CliTests.fs
+++ b/tests/CliTests.fs
@@ -1,0 +1,21 @@
+module FSharpFHIR.Tests.CliTests
+
+open Expecto
+open System.IO
+open FSharpFHIR.Cli
+open FSharpFHIR.ResourceValidation
+
+[<Tests>]
+let tests =
+    testList "cli validation" [
+        testCase "validate command returns success" <| fun _ ->
+            let exitCode = run [| "validate"; patientSamplePath |]
+            Expect.equal exitCode 0 "successful validation should return 0"
+
+        testCase "validate command returns failure for invalid JSON" <| fun _ ->
+            let temp = Path.GetTempFileName()
+            File.WriteAllText(temp, "{}")
+            let exitCode = run [| "validate"; temp |]
+            File.Delete(temp)
+            Expect.equal exitCode 1 "invalid json should fail"
+    ]

--- a/tests/FSharpFHIR.Tests.fsproj
+++ b/tests/FSharpFHIR.Tests.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ResourceValidation.fs" />
+    <Compile Include="Cli.fs" />
+    <Compile Include="PrimitiveSerializationTests.fs" />
+    <Compile Include="ResourceValidationTests.fs" />
+    <Compile Include="CliTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Expecto" Version="9.0.4" />
+    <PackageReference Include="Expecto.TestAdapter" Version="9.0.4" />
+  </ItemGroup>
+</Project>

--- a/tests/PrimitiveSerializationTests.fs
+++ b/tests/PrimitiveSerializationTests.fs
@@ -1,0 +1,30 @@
+module FSharpFHIR.Tests.PrimitiveSerializationTests
+
+open Expecto
+open System.Text.Json
+
+/// Helpers for round-trip serialization using System.Text.Json.
+module Primitive =
+    /// Serialize a value to JSON and deserialize it back.
+    let roundTrip<'a> (value: 'a) =
+        let json = JsonSerializer.Serialize<'a> value
+        JsonSerializer.Deserialize<'a> json
+
+[<Tests>]
+let tests =
+    testList "primitive roundtrip" [
+        testCase "string roundtrips" <| fun _ ->
+            let v = "hello"
+            let result = Primitive.roundTrip v
+            Expect.equal result v "string should roundtrip"
+
+        testCase "int roundtrips" <| fun _ ->
+            let v = 42
+            let result = Primitive.roundTrip v
+            Expect.equal result v "int should roundtrip"
+
+        testCase "boolean roundtrips" <| fun _ ->
+            let v = true
+            let result = Primitive.roundTrip v
+            Expect.equal result v "boolean should roundtrip"
+    ]

--- a/tests/ResourceValidation.fs
+++ b/tests/ResourceValidation.fs
@@ -1,0 +1,20 @@
+module FSharpFHIR.ResourceValidation
+
+open System.IO
+open System.Text.Json
+
+/// Path to the sample Patient resource JSON used by tests and CLI scenarios.
+let patientSamplePath =
+    Path.Combine(__SOURCE_DIRECTORY__, "..", "examples", "patient.json")
+
+/// Performs a basic validation by ensuring the JSON contains a Patient resource
+/// with an `id` field.
+let isValid (path: string) =
+    let json = File.ReadAllText path
+    use doc = JsonDocument.Parse json
+    let root = doc.RootElement
+    let mutable resourceType = Unchecked.defaultof<JsonElement>
+    let mutable id = Unchecked.defaultof<JsonElement>
+    let hasResourceType = root.TryGetProperty("resourceType", &resourceType)
+    let hasId = root.TryGetProperty("id", &id)
+    hasResourceType && hasId && resourceType.GetString() = "Patient"

--- a/tests/ResourceValidationTests.fs
+++ b/tests/ResourceValidationTests.fs
@@ -1,0 +1,11 @@
+module FSharpFHIR.Tests.ResourceValidationTests
+
+open Expecto
+open FSharpFHIR.ResourceValidation
+
+[<Tests>]
+let tests =
+    testList "resource validation" [
+        testCase "patient example is valid" <| fun _ ->
+            Expect.isTrue (isValid patientSamplePath) "sample patient should validate"
+    ]


### PR DESCRIPTION
## Summary
- set up `FSharpFHIR.Tests` targeting .NET 10 with Expecto
- rewrite primitive serialization, resource validation, and CLI tests using Expecto
- include sample Patient JSON and validation/CLI helpers

## Testing
- `dotnet test tests/FSharpFHIR.Tests.fsproj -v n` *(fails: NETSDK1045: .NET SDK 8.0 does not support targeting .NET 10.0)*

------
https://chatgpt.com/codex/tasks/task_e_689dabc036748332966d5a2e3594ddd5